### PR TITLE
Fix #1 avoid passing .shell to spawn so it works in all versions of node

### DIFF
--- a/index.js
+++ b/index.js
@@ -9,7 +9,6 @@ const npmRunPath = require('npm-run-path');
 
 const defaultOptions = {
   env: {},
-  shell: defaultShell,
   stdio: [0, 1, 2],
   windowsVerbatimArguments: process.platform === 'win32'
 };
@@ -39,10 +38,12 @@ function resolveOnProcessExit(p) {
 
 module.exports = function spawnShell(command, options) {
   const opts = merge({}, defaultOptions, options);
+  const shell = opts.shell || defaultShell;
+  delete opts.shell;
   opts.env.PATH = npmRunPath({path: opts.env.PATH});
 
   const p = spawn(
-    opts.shell,
+    shell,
     shellFlags().concat(command),
     opts
   );


### PR DESCRIPTION
The old way still works, it's just that the opts object cannot contain `shell` if spawn is to behave as it used to.

Starting with node v4.8.0 this module is actually not needed. So working everywhere seems like a good goal.